### PR TITLE
Copy BigCommerce ids to new fields to prevent Gatsby from overwriting context

### DIFF
--- a/request.js
+++ b/request.js
@@ -21,11 +21,11 @@ function parseResponse(res, body, resolve, reject) {
     }
 
     if (json.data.length) {
-      // For BC API responses that return arrays, copy the id returned to a 'bc_id' field so
+      // For BC API responses that return arrays, copy the id returned to a 'bigcommerce_id' field so
       // it can still be referenced after the Gatsby generated id overwrites it
       json.data.forEach(function(entity) {
         if (entity.id) {
-          entity.bc_id = entity.id;
+          entity.bigcommerce_id = entity.id;
         }
       });
     }

--- a/request.js
+++ b/request.js
@@ -20,6 +20,16 @@ function parseResponse(res, body, resolve, reject) {
       return reject(err);
     }
 
+    if (json.data.length) {
+      // For BC API responses that return arrays, copy the id returned to a 'bc_id' field so
+      // it can still be referenced after the Gatsby generated id overwrites it
+      json.data.forEach(function(entity) {
+        if (entity.id) {
+          entity.bc_id = entity.id;
+        }
+      });
+    }
+
     return resolve(json);
   } catch (e) {
     e.responseBody = body;


### PR DESCRIPTION
**What**

For BC API responses that return arrays, copy the id returned to a 'bigcommerce_id' field so
it can still be referenced after the Gatsby generated id overwrites it.

**Why**

Gatsby uses the id fields for it's own internal reference and creates new ids that overwrite BC's id field. So there is no way to filter down to the right brand id, for instance, since it's brand_id on the product, but id on the brand resource, which Gatsby would overwrite with an uuid. 

**Proof**

Locally, getting both Gatsby id and BC id for entities in the same request:

<img width="1315" alt="Screen Shot 2019-10-13 at 7 36 08 PM" src="https://user-images.githubusercontent.com/2677921/66724884-cab05b00-edf0-11e9-86ec-bc32c337c1bb.png">

