### PR TITLE
Upgrade proxy

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -6,7 +6,7 @@ const micro = require(`micro`);
 
 const fetch = require("node-fetch");
 
-const proxy = require("http-proxy-middleware");
+const { createProxyMiddleware } = require('http-proxy-middleware')
 
 exports.sourceNodes = async ({
   actions,
@@ -104,7 +104,7 @@ exports.sourceNodes = async ({
 exports.onCreateDevServer = ({
   app
 }) => {
-  app.use("/___BCPreview/", proxy({
+  app.use("/___BCPreview/", createProxyMiddleware({
     target: `http://localhost:8033`,
     secure: false
   }));

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
-    "cross-env": "^5.1.4"
+    "cross-env": "^5.1.4",
+    "http-proxy-middleware": "^1.0.5"
   }
 }

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -3,7 +3,7 @@
 const BigCommerce = require("./bigcommerce");
 const micro = require(`micro`);
 const fetch = require("node-fetch");
-const proxy = require("http-proxy-middleware");
+const { createProxyMiddleware } = require('http-proxy-middleware')
 
 exports.sourceNodes = async (
   { actions, createNodeId, createContentDigest },
@@ -124,7 +124,7 @@ exports.sourceNodes = async (
 exports.onCreateDevServer = ({ app }) => {
   app.use(
     "/___BCPreview/",
-    proxy({
+    createProxyMiddleware({
       target: `http://localhost:8033`,
       secure: false
     })


### PR DESCRIPTION
Basically, just implementing [this update as noted in the Gatsby docs.](https://www.gatsbyjs.com/docs/api-proxy/#advanced-proxying)

```javascript
const { createProxyMiddleware } = require("http-proxy-middleware") //v1.x.x
// Use implicit require for v0.x.x of 'http-proxy-middleware'
// const proxy = require('http-proxy-middleware')
// be sure to replace 'createProxyMiddleware' with 'proxy' where applicable
```