### PR TITLE
Respect BigCommerce response pagination in endpoints

### DIFF
--- a/src/bigcommerce.js
+++ b/src/bigcommerce.js
@@ -137,7 +137,37 @@ class BigCommerce {
       fullPath += path;
     }
 
-    return await request.run(type, fullPath, data);
+    const response = await request.run(type, fullPath, data);
+
+    // If response contains pagination.
+    if ('meta' in response && 'pagination' in response.meta) {
+      const {
+        total_pages: totalPages,
+        current_page: currentPage
+      } = response.meta.pagination;
+      // If current page is not the last page.
+      if (totalPages > currentPage) {
+        // Collect all page request promises in array.
+        const promises = []
+        for (let nextPage = (currentPage + 1); nextPage <= totalPages; nextPage++) {
+          const endpointUrl = new URL(fullPath, `https://${request.hostname}`);
+          // Safely assign `page` query parameter to endpoint URL.
+          endpointUrl.searchParams.set('page', nextPage);
+          // Add promise to array for future Promise.All() call.
+          promises.push(request.run(type, `${endpointUrl.pathname}${endpointUrl.search}`, data));
+        }
+        // Request all endpoints in parallel.
+        const responses = await Promise.all(promises);
+        responses.forEach(pageResponse => {
+          response.data = response.data.concat(pageResponse.data)
+        })
+        // Set pager to last page.
+        response.meta.pagination.total_pages = totalPages;
+        response.meta.pagination.current_page = totalPages;
+      }
+    }
+
+    return response;
   }
 
   async get(path) {


### PR DESCRIPTION
## Motivation and context

Gatsby needs to collect all the data from the source for correct GraphQL work (including sorting and filtering). Current implementation returns 50 items at most because BigCommerce API designed this way. For collecting the next portion of the data (next 50 items) from BigCommerce, an additional `?page=${nextPageNumber}` query parameter needs to be added to the API request.

This change is required for projects that have in BigCommerce more than 50 items in products, categories, product variants, etc. in order to be able to build a Gatsby site with the correct amount of data retrieved from BigCommerce.

## How has this been tested?

I've done the following on current plugin implementation: 

- Created 1'000+ categories using BigCommerce API
- Added new endpoint with categories:
  ```js
    {
      resolve: 'gatsby-source-bigcommerce',
      options: {
      ...
        endpoints: {
          BigCommerceCategories: "/catalog/categories",
        }
      }
    },
  ``` 
- Opened Gatsby's GraphiQL interface at http://localhost:8000/___graphql
- Ran following query:
  ```graphql
  query AllCategories {
    allBigCommerceCategories {
      totalCount
    }
  }
  ```

### Actual behavior

Response with only 50 items:

```json
{
  "data": {
    "allBigCommerceCategories": {
      "totalCount": 50
    }
  }
}
```

### Expected behavior

Get count of all my BigCommerce categories:

```json
{
  "data": {
    "allBigCommerceCategories": {
      "totalCount": 1024
    }
  }
}
```